### PR TITLE
allow underscores in tag ids

### DIFF
--- a/spec/view.spec.coffee
+++ b/spec/view.spec.coffee
@@ -193,3 +193,6 @@ describe 'View', ->
       expect(result.name).toEqual('div')
       expect(result.children[0].name).toEqual('ul')
       expect(result.children[1].name).toEqual('form')
+
+    it 'parses a tag containing an underscore in the short form id', ->
+      expect(parse('div#foo_bar').id).toEqual('foo_bar')

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -1,4 +1,4 @@
-IDENTIFIER = /^[a-zA-Z][a-zA-Z0-9\-]*/
+IDENTIFIER = /^[a-zA-Z][a-zA-Z0-9\-_]*/
 
 LITERAL = /^[\[\]=\:\-!#\.@]/
 


### PR DESCRIPTION
We often write our HTML with underscores used in the tag identifiers. Unless you had a specific reason not to allow this functionality I would like to have it.
