### PR TITLE
Fixes Model.set if there are null values present

### DIFF
--- a/src/properties.coffee
+++ b/src/properties.coffee
@@ -77,7 +77,7 @@ Serenade.Properties =
 
   _defer: (name) ->
     deferred = @get(name)
-    if deferred?._triggerChangesTo
+    if deferred? and deferred?._triggerChangesTo
       deferred._deferTo or= {}
       deferred._deferTo?[name] = this
 


### PR DESCRIPTION
When running in the browser, the following code will fail:

```
data = {first: 'John', middle: null, last: 'Doe'}
person = Serenade.Model.find(0)
person.set(data)
```

This works server side when running in node, but fails in the browser.  Adding an extra null check seems to fix it.  Was unable to replicate in node, so there are no jasmine tests to go along with it, but this small change seemed to fix the problem for me.

Cheers,
Steve
