### PR TITLE
Options (like serialize) passed to collection are not passed-on to properties.

### DIFF
--- a/spec/properties.spec.coffee
+++ b/spec/properties.spec.coffee
@@ -84,6 +84,10 @@ describe 'Serenade.Properties', ->
       @object.collection 'numbers'
       @object.get('numbers').push(4)
       expect(@object).toHaveReceivedEvent('change:numbers', with: [@object.get('numbers')])
+    it 'passes on the serialize option', ->
+      @object.collection 'numbers', serialize: true
+      @object.set('numbers', [1,2,3])
+      expect(@object.serialize()).toEqual(numbers: [1,2,3])
 
   describe '.set', ->
     describe 'with a single property', ->

--- a/src/properties.coffee
+++ b/src/properties.coffee
@@ -20,8 +20,8 @@ Serenade.Properties =
         get: -> @get(name)
         set: (v) -> @set(name, v)
 
-  collection: (name, options) ->
-    @property name,
+  collection: (name, options={}) ->
+    extend options,
       get: ->
         unless @attributes[name]
           @attributes[name] = new Collection([])
@@ -31,6 +31,7 @@ Serenade.Properties =
         @attributes[name]
       set: (value) ->
         @get(name).update(value)
+    @property name, options
 
   set: (attributes, value) ->
     attributes = pairToObject(attributes, value) if typeof(attributes) is 'string'


### PR DESCRIPTION
This patch (with test) passes on those options, so that collection properties can be serialized.
