### PR TITLE
have render return element, which is more predictable

### DIFF
--- a/spec/integration/custom_helper.spec.coffee
+++ b/spec/integration/custom_helper.spec.coffee
@@ -73,7 +73,6 @@ describe 'Custom helpers', ->
       Serenade.Helpers.form = ->
         element = @document.createElement('form')
         @render(element)
-        element
       @render '''
         div
           - form
@@ -95,7 +94,6 @@ describe 'Custom helpers', ->
       Serenade.Helpers.form = ->
         element = @document.createElement('form')
         @render(element, name: 'peter')
-        element
       @render '''
         div
           - form
@@ -108,7 +106,6 @@ describe 'Custom helpers', ->
       Serenade.Helpers.form = ->
         element = @document.createElement('form')
         @render(element, null, funky: -> funked = true)
-        element
       @render '''
         div
           - form
@@ -123,7 +120,6 @@ describe 'Custom helpers', ->
         element = @document.createElement('form')
         @render(element, name: 'jonas')
         @render(element, name: 'peter')
-        element
       @render '''
         div
           - form

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -237,6 +237,7 @@ class Helper
     for child in @ast.children
       node = Nodes.compile(child, @document, model, controller)
       node.append(element)
+    element
 
   lastElement: ->
     item = @lastItem()


### PR DESCRIPTION
In writing a custom helper, I found it odd that the helper's @render didn't return the element, so I tweaked it. The tests pass either way, but I've tweaked them as well, so that if the behavior reverts, the tests will blow up, making that obvious.
