### PR TITLE
sortBy for both object literals and Serenade models

### DIFF
--- a/src/collection.coffee
+++ b/src/collection.coffee
@@ -1,5 +1,5 @@
 {Events} = require './events'
-{extend, forEach, serializeObject, deleteItem, indexOf} = require './helpers'
+{extend, forEach, serializeObject, deleteItem, indexOf, get} = require './helpers'
 
 class exports.Collection
   extend(@prototype, Events)
@@ -29,7 +29,7 @@ class exports.Collection
     @list.sort(fun)
     @trigger("update", @list)
   sortBy: (attribute) ->
-    @sort((a, b) -> if a[attribute] < b[attribute] then -1 else 1)
+    @sort((a, b) -> if get(a, attribute) < get(b, attribute) then -1 else 1)
   forEach: (fun) ->
     forEach(@list, fun)
   map: (fun) ->

--- a/test/collection.spec.coffee
+++ b/test/collection.spec.coffee
@@ -56,6 +56,14 @@ describe 'Serenade.Collection', ->
       @collection.sortBy('name')
       expect(@collection.list).to.eql([item2, item1])
 
+    it 'works with Serenade Models', ->
+      item1 = new Serenade.Model(name: 'CJ', age: 30)
+      item2 = new Serenade.Model(name: 'Anders', age: 37)
+      @collection.update([item1, item2])
+
+      @collection.sortBy('name')
+      expect(@collection.list).to.eql([item2, item1])
+
   describe '#push', ->
     it 'adds an item to the collection', ->
       @collection.push('g')


### PR DESCRIPTION
Fix for
[Issue #35](https://github.com/elabs/serenade.js/issues/35)

sortBy will now work in IE even if the item is a Serenade.Model
