### PR TITLE
Add view name to syntaxt error message, parse view only once.

### DIFF
--- a/src/view.coffee
+++ b/src/view.coffee
@@ -16,7 +16,11 @@ class View
   constructor: (@name, @view) ->
   parse: ->
     if typeof(@view) is 'string'
-      @view = parser.parse(new Lexer().tokenize(@view))
+      try
+        @view = parser.parse(new Lexer().tokenize(@view))
+      catch e
+        e.message = "In view '#{@name}': #{e.message}"
+        throw e
     else
       @view
   render: (model, controller, parent, skipCallback) ->

--- a/test/view.spec.coffee
+++ b/test/view.spec.coffee
@@ -223,3 +223,6 @@ describe 'View', ->
       expect(result.children[0].name).to.eql('ul')
       expect(result.children[0].children[0].name).to.eql('li')
       expect(result.children[0].children[1].name).to.eql('p')
+
+    it 'it adds view name to error message', ->
+      expect(-> parse('div\ndiv')).to.throw(Error, /In view '.*': .*/)


### PR DESCRIPTION
View parse tree caching makes huge difference in slow IE8.
