### PR TITLE
Fix duplicates in inverse hasMany relationships (closes elabs/serenade.js#69)

### DIFF
--- a/src/association_collection.coffee
+++ b/src/association_collection.coffee
@@ -2,29 +2,39 @@
 
 class AssociationCollection extends Collection
   constructor: (@owner, @options, list) ->
-    super(@_convert(item) for item in list)
+    @_convert list..., (items...) =>
+      super(items)
 
   set: (index, item) ->
-    super(index, @_convert(item))
+    @_convert item, (item) =>
+      super(index, item)
 
   push: (item) ->
-    super(@_convert(item))
+    @_convert item, (item) =>
+      super(item)
 
   update: (list) ->
-    super(@_convert(item) for item in list)
+    @_convert list..., (items...) =>
+      super(items)
 
   splice: (start, deleteCount, list...) ->
-    list = (@_convert(item) for item in list)
-    super(start, deleteCount, list...)
+    @_convert list..., (items...) =>
+      super(start, deleteCount, items...)
 
   insertAt: (index, item) ->
-    super(index, @_convert(item))
+    @_convert item, (item) =>
+      super(index, item)
 
-  _convert: (item) ->
-    if item.constructor is Object and @options.as
-      item = new (@options.as())(item)
-    if @options.inverseOf and item[@options.inverseOf] isnt @owner
-      item[@options.inverseOf] = @owner
-    item
+  _convert: (items..., fn) ->
+    items = for item in items
+      if item?.constructor is Object and @options.as
+        item = new (@options.as())(item)
+      else
+        item
+    returnValue = fn(items...)
+    for item in items
+      if @options.inverseOf and item[@options.inverseOf] isnt @owner
+        item[@options.inverseOf] = @owner
+    returnValue
 
 exports.AssociationCollection = AssociationCollection

--- a/test/model.spec.coffee
+++ b/test/model.spec.coffee
@@ -326,6 +326,16 @@ describe 'Serenade.Model', ->
         @hasMany 'comments', inverseOf: "post", as: -> Comment
       post = new Post(comments: [{ body: "hey" }])
       expect(post.comments[0].post).to.eql(post)
+      expect(post.comments.length).to.eql(1)
+    it 'does not push itself twice to its inverse association', ->
+      class Comment extends Serenade.Model
+        @belongsTo "post", inverseOf: "comments", as: -> Post
+      class Post extends Serenade.Model
+        @hasMany 'comments', inverseOf: "post", as: -> Comment
+      post = new Post()
+      post.comments.push({})
+      expect(post.comments[0].post).to.eql(post)
+      expect(post.comments.length).to.eql(1)
 
   describe ".delegate", ->
     it "sets up delegated attributes", ->


### PR DESCRIPTION
A fix for #69. Didn’t want to apply it to the repository without it getting looked through by another pair of eyes.
