### PR TITLE
Give property formatters access to their model instance

### DIFF
--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -8,7 +8,7 @@ Helpers =
     value = model[key]
     formatter = model[Helpers.prefix + key]?.format
     if typeof(formatter) is 'function'
-      formatter.call(this, value)
+      formatter.call(model, value)
     else
       value
 

--- a/test/serenade.spec.coffee
+++ b/test/serenade.spec.coffee
@@ -61,3 +61,9 @@ describe "Serenade", ->
       @object.property('foo', format: (x) -> x + 2)
       @object.set('foo', 23)
       expect(Serenade.format(@object, 'foo')).to.eql(25)
+    it 'properly assigns the formatters scope', ->
+      @object = Serenade({})
+      @object.property('bar', get: -> 2)
+      @object.property('foo', format: (x) -> x + @bar)
+      @object.set('foo', 23)
+      expect(Serenade.format(@object, 'foo')).to.eql(25)


### PR DESCRIPTION
This patch allows helpers to call instance methods (or retrieve properties) of the object they receive their value from.
