### PR TITLE
Set writable to true when defining property to be Safari 5 compatible.

### DIFF
--- a/src/property.coffee
+++ b/src/property.coffee
@@ -49,7 +49,7 @@ class PropertyAccessor
     if @definition.set
       @definition.set.call(@object, value)
     else
-      def @object, @valueName, value: value, configurable: true
+      def @object, @valueName, value: value, configurable: true, writable: true
 
   set: (value) ->
     if typeof(value) is "function"


### PR DESCRIPTION
Fixes issue #100.
