### PR TITLE
Fixes NPM warnings on 1.3.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
            "url": "https://github.com/elabs/serenade.js/blob/master/LICENSE"
        }
    ],
-   "repositories": [
+   "repository": [
        {
            "type": "git",
            "url": "git@github.com:elabs/serenade.js.git"


### PR DESCRIPTION
Example of error message:

```
$ npm install
npm WARN package.json serenade@0.5.0 'repositories' (plural) Not supported.
npm WARN package.json Please pick one as the 'repository' field
```
